### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/src/utilities/focus.scss
+++ b/src/utilities/focus.scss
@@ -8,7 +8,7 @@
     background-color: var(--gcds-focus-background);
     color: var(--gcds-focus-text);
     text-decoration: none;
-    box-shadow: 0 0 0 var(--gcds-border-width-md) var(--gcds-color-white);
+    box-shadow: 0 0 0 var(--gcds-border-width-md) var(--gcds-focus-ring);
     outline-offset: var(--gcds-border-width-md);
     outline: var(--gcds-border-width-lg) solid var(--gcds-focus-background);
   }

--- a/src/utilities/focus.scss
+++ b/src/utilities/focus.scss
@@ -2,7 +2,10 @@
 
 /* --- Focus --- */
 
-@include mixins.classWithBreakpoints('focus\\:default', 'false') {
+@include mixins.classWithBreakpoints(
+  'focus\\:default',
+  'false' // Indicates that responsive breakpoint variants are disabled for this focus utility.
+) {
   &:focus {
     border-radius: var(--gcds-border-radius-sm);
     background-color: var(--gcds-focus-background);


### PR DESCRIPTION
This PR still needs to be reviewed. It's from the code quality AI findings tool

_This PR applies 2/3 suggestions from code quality [AI findings](https://github.com/cds-snc/gcds-css-shortcuts/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._

1 / 3
> [nitpick] The class name 'focus\:default' is ambiguous. Consider using a more descriptive name like 'focus\:ring' or 'focus\:outline' to better indicate what this focus style provides.

Suggestion:
Change
```scss
@include mixins.classWithBreakpoints('focus\\:default', 'false') 
```

To
```scss
@include mixins.classWithBreakpoints('focus\\:outline', 'false') {
```

2 / 3 
> The second parameter 'false' passed to classWithBreakpoints is unclear without context. Consider using a named parameter or adding a comment to explain what this boolean controls.

Suggestion:
Change
```scss
@include mixins.classWithBreakpoints('focus\\:default', 'false') {
```

To
```scss
@include mixins.classWithBreakpoints(
  'focus\\:default',
   'false' // Indicates that responsive breakpoint variants are disabled for this focus utility.
  ) {

```

3 / 3
> The box-shadow uses hardcoded white color instead of a semantic focus-related CSS variable. Consider using a dedicated focus ring color variable for better maintainability and theme consistency.

Suggestion
Change:
```scss
    box-shadow: 0 0 0 var(--gcds-border-width-md) var(--gcds-color-white);
```
To:
```scss
    box-shadow: 0 0 0 var(--gcds-border-width-md) var(--gcds-focus-ring);
```